### PR TITLE
Upgrade to DJL 0.8.0

### DIFF
--- a/djl-spring-boot-console-sample/pom.xml
+++ b/djl-spring-boot-console-sample/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>ai.djl.tensorflow</groupId>
             <artifactId>tensorflow-api</artifactId>
-            <version>0.7.0</version>
+            <version>0.8.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/djl-spring-boot-starter-autoconfigure/src/test/java/ai/djl/spring/configuration/DjlAutoConfigurationTest.java
+++ b/djl-spring-boot-starter-autoconfigure/src/test/java/ai/djl/spring/configuration/DjlAutoConfigurationTest.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.spring.configuration;
 
+import ai.djl.Device;
 import ai.djl.MalformedModelException;
 import ai.djl.modality.cv.Image;
 import ai.djl.modality.cv.output.DetectedObjects;
@@ -125,7 +126,7 @@ public class DjlAutoConfigurationTest {
         @Bean
         public ZooModel<Image, DetectedObjects> model(@Qualifier("criteria") Map<String, String> criteria)
                 throws MalformedModelException, ModelNotFoundException, IOException {
-            return MxModelZoo.SSD.loadModel(criteria, new ProgressBar());
+            return MxModelZoo.SSD.loadModel(criteria, Device.defaultDevice(), new ProgressBar());
         }
     }
 

--- a/djl-spring-boot-starter-parent/pom.xml
+++ b/djl-spring-boot-starter-parent/pom.xml
@@ -34,7 +34,7 @@
     </distributionManagement>
 
     <properties>
-        <djl.version>0.7.0</djl.version>
+        <djl.version>0.8.0</djl.version>
         <java.version>11</java.version>
         <jna.version>5.3.0</jna.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>

--- a/djl-spring-boot-starter-pytorch-auto/pom.xml
+++ b/djl-spring-boot-starter-pytorch-auto/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>ai.djl.pytorch</groupId>
       <artifactId>pytorch-native-auto</artifactId>
-      <version>${pytorch.native.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/djl-spring-boot-starter-tensorflow-auto/pom.xml
+++ b/djl-spring-boot-starter-tensorflow-auto/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>ai.djl.tensorflow</groupId>
       <artifactId>tensorflow-native-auto</artifactId>
-      <version>${tensorflow.native.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrade to DJL 0.8.0 version
removed pytorch.native.version and tensorflow.native.version as they are sourced from BOM

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
