### PR TITLE
Overriding jna version no longer required, upgrading Spring Boot

### DIFF
--- a/djl-spring-boot-console-sample/pom.xml
+++ b/djl-spring-boot-console-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
-        <version>2.3.3.RELEASE</version>
+        <version>2.3.4.RELEASE</version>
     </parent>
     <groupId>ai.djl.spring.examples</groupId>
     <artifactId>djl-spring-boot-console-sample</artifactId>
@@ -13,7 +13,6 @@
 
     <properties>
         <java.version>11</java.version>
-        <jna.version>5.3.0</jna.version> <!--Required to override default JNA version for Spring Boot parent-->
     </properties>
 
     <dependencies>

--- a/djl-spring-boot-starter-parent/pom.xml
+++ b/djl-spring-boot-starter-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <version>2.3.4.RELEASE</version>
         <relativePath />
         <!-- lookup parent from repository -->
     </parent>
@@ -36,7 +36,6 @@
     <properties>
         <djl.version>0.7.0</djl.version>
         <java.version>11</java.version>
-        <jna.version>5.3.0</jna.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <mxnet.native.version>1.7.0-a</mxnet.native.version>
@@ -67,11 +66,6 @@
         <dependency>
             <groupId>ai.djl</groupId>
             <artifactId>api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>      <!-- overrides default spring boot version to comply with DJL -->
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
*Description of changes:*
I upgraded Spring Boot to version 2.3.4. While taking a closer look, I noticed that the jna version override is no longer needed (probably already changed for 2.3.x earlier).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
